### PR TITLE
Add Debian 12 bookworm

### DIFF
--- a/debian-12-bookworm-x86/Dockerfile
+++ b/debian-12-bookworm-x86/Dockerfile
@@ -2,7 +2,7 @@
 # and then https://github.com/matthew-brett/trusty/blob/32/Dockerfile
 
 FROM scratch
-ADD debian-bullseye-i386.tgz /
+ADD debian-bookworm-i386.tgz /
 
 # a few minor docker-specific tweaks
 # see https://github.com/docker/docker/blob/master/contrib/mkimage/debootstrap
@@ -82,4 +82,4 @@ USER pillow
 ENTRYPOINT ["linux32"]
 CMD ["depends/test.sh"]
 
-#docker run -v $GITHUB_WORKSPACE:/Pillow pythonpillow/debian-11-bullseye-x86
+#docker run -v $GITHUB_WORKSPACE:/Pillow pythonpillow/debian-12-bookworm-x86

--- a/debian-12-bookworm-x86/Dockerfile
+++ b/debian-12-bookworm-x86/Dockerfile
@@ -66,7 +66,6 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --de
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN useradd pillow \
-    && addgroup pillow sudo \
     && mkdir /home/pillow \
     && chown pillow:pillow /home/pillow
 

--- a/debian-12-bookworm-x86/Dockerfile
+++ b/debian-12-bookworm-x86/Dockerfile
@@ -69,7 +69,7 @@ RUN useradd pillow \
     && mkdir /home/pillow \
     && chown pillow:pillow /home/pillow
 
-RUN virtualenv -p /usr/bin/python3.9 --system-site-packages /vpy3 \
+RUN virtualenv -p /usr/bin/python3.11 --system-site-packages /vpy3 \
     && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
     && /vpy3/bin/pip install --no-cache-dir cffi olefile pytest pytest-cov pytest-timeout \
     && chown -R pillow:pillow /vpy3

--- a/debian-12-bookworm-x86/update.sh
+++ b/debian-12-bookworm-x86/update.sh
@@ -5,7 +5,7 @@ set -e
 
 ### settings
 arch=i386
-suite="bullseye"
+suite="bookworm"
 chroot_dir="./guest-root"
 apt_mirror="http://http.debian.net/debian"
 


### PR DESCRIPTION
A few changes for https://github.com/python-pillow/docker-images/pull/184

- Use Bookworm, instead of Bullseye in a few locations.

After that, I get ["addgroup: addgroup with two arguments is an unspecified operation."](https://github.com/radarhere/docker-images/actions/runs/5232100232/jobs/9446637305). If I try only "pillow" rather than "pillow sudo", I get ["addgroup: The group `pillow' already exists."](https://github.com/radarhere/docker-images/actions/runs/5232124412/jobs/9446681147)

- Removed addgroup

After that, I find that [the Python version is incorrect.](https://github.com/radarhere/docker-images/actions/runs/5232166669/jobs/9446745079)

- Use Python 3.11